### PR TITLE
Add CD workflow to push containers to GitHub Packages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 tmp/
+log/
 .git/
 node_modules/
 spec/

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'master'
-      - 'feature/ghcr-package' # TEMPORARY: To make sure we merge a green PR
     tags:
       - 'v*'
 
@@ -28,8 +27,5 @@ jobs:
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
           # Use Docker `latest` tag convention for master
           [ "$VERSION" == "master" ] && VERSION=latest
-          # TEMPORARY: Always build “latest”
-          VERSION=latest
-          VERSION=$VERSION make
           VERSION=$VERSION make build
           VERSION=$VERSION make push

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,10 +4,9 @@ on:
   push:
     branches:
       - 'master'
+      - 'feature/ghcr-package'
     tags:
       - 'v*'
-    pull_request:
-      - 'feature/ghcr-package'
 
 jobs:
   push:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,22 +4,22 @@ on:
   push:
     branches:
       - 'master'
-      - 'feature/ghcr-package'
+      - 'feature/ghcr-package' # TEMPORARY: To make sure we merge a green PR
     tags:
       - 'v*'
 
 jobs:
   push:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
+
+    env:
+      DOCKER_USERNAME: mirego-builds
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Log in to registry
-        run: echo "${{ secrets.MIREGO_GITHUB_PACKAGES_ACCESS_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.MIREGO_GITHUB_PACKAGES_ACCESS_TOKEN }}" | docker login ghcr.io -u $DOCKER_USERNAME --password-stdin
 
       - name: Build and push image
         run: |
@@ -28,7 +28,7 @@ jobs:
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
           # Use Docker `latest` tag convention for master
           [ "$VERSION" == "master" ] && VERSION=latest
-          # This is temporary — always build “latest”
+          # TEMPORARY: Always build “latest”
           VERSION=latest
           VERSION=$VERSION make
           VERSION=$VERSION make build

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Log in to registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.MIREGO_GITHUB_PACKAGES_ACCESS_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push image
         run: |

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -28,6 +28,8 @@ jobs:
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
           # Use Docker `latest` tag convention for master
           [ "$VERSION" == "master" ] && VERSION=latest
+          # This is temporary — always build “latest”
+          VERSION=latest
           VERSION=$VERSION make
           VERSION=$VERSION make build
           VERSION=$VERSION make push

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,36 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*'
+    pull_request:
+      - 'feature/ghcr-package'
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: make build
+
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention for master
+          [ "$VERSION" == "master" ] && VERSION=latest
+          VERSION=$VERSION make
+          VERSION=$VERSION make push

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -18,13 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build image
-        run: make build
-
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Push image
+      - name: Build and push image
         run: |
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           # Strip "v" prefix from tag name
@@ -32,4 +29,5 @@ jobs:
           # Use Docker `latest` tag convention for master
           [ "$VERSION" == "master" ] && VERSION=latest
           VERSION=$VERSION make
+          VERSION=$VERSION make build
           VERSION=$VERSION make push

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # Build configuration
 # -------------------
 
-GIT_REVISION = `git rev-parse HEAD`
-DOCKER_REGISTRY ?=
-DOCKER_LOCAL_IMAGE = killswitch:$(GIT_REVISION)
+VERSION ?= `git rev-parse HEAD`
+DOCKER_REGISTRY = ghcr.io
+DOCKER_LOCAL_IMAGE = mirego/killswitch:$(VERSION)
 DOCKER_REMOTE_IMAGE = $(DOCKER_REGISTRY)/$(DOCKER_LOCAL_IMAGE)
 
 # Linter and formatter configuration
@@ -23,8 +23,8 @@ help: header targets
 header:
 	@echo "\033[34mEnvironment\033[0m"
 	@echo "\033[34m---------------------------------------------------------------\033[0m"
-	@printf "\033[33m%-23s\033[0m" "GIT_REVISION"
-	@printf "\033[35m%s\033[0m" $(GIT_REVISION)
+	@printf "\033[33m%-23s\033[0m" "VERSION"
+	@printf "\033[35m%s\033[0m" $(VERSION)
 	@echo ""
 	@printf "\033[33m%-23s\033[0m" "DOCKER_REGISTRY"
 	@printf "\033[35m%s\033[0m" $(DOCKER_REGISTRY)

--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ The project exposes a `GET /health` route that contains checks to make sure the 
 
 A Docker image can be created with `make build` and pushed to a registry with `make push`.
 
+[Official Docker images](https://github.com/mirego/killswitch/pkgs/container/killswitch) can be pulled from GitHub Container registry. For example, to get the latest `master` image:
+
+```shell-session
+$ docker pull ghcr.io/mirego/killswitch:latest
+```
+
 ## License
 
 Killswitch is © 2013-2022 [Mirego](https://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause). See the [`LICENSE.md`](https://github.com/mirego/killswitch/blob/master/LICENSE.md) file.


### PR DESCRIPTION
## 📖 Description and motivation

Let’s use GHCR (GitHub Container Registry) to host the project’s Docker images.

## 👷 Work done

#### Tasks

- [x] Add CD workflow to build and release to ghcr.io when pushing on `master` (`latest`) or a tag

#### Additional notes

This workflow uses a new organization secret (`MIREGO_GITHUB_PACKAGES_ACCESS_TOKEN`) that only has permissions related to packages.

:wave: @simonprev @garno The whole workflow should be pretty easy to reuse for Accent and Dispatch 🤓 

## 🎉 Result

<img width="752" alt="" src="https://user-images.githubusercontent.com/11348/154070080-d0708b34-cccc-44e6-b861-2358aff55092.png">

## 🦀 Dispatch

`#dispatch/devops`
