### PR TITLE
Add better structure to CD workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -31,7 +31,7 @@ jobs:
     needs: set-docker-tag
     runs-on: ubuntu-latest
     env:
-      DOCKER_TAG: ${{needs.set-docker-tag.outputs.tag}}
+      DOCKER_TAG: ${{needs.set-docker-tag.outputs.docker-tag}}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -28,7 +28,7 @@ jobs:
           echo "::set-output name=tag::$TAG"
 
   build:
-    needs: docker-tag
+    needs: set-docker-tag
     runs-on: ubuntu-latest
     env:
       DOCKER_TAG: ${{needs.set-docker-tag.outputs.tag}}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'master'
-      - 'feature/add-better-structure-to-cd-workflow' # TEMPORARY
     tags:
       - 'v*'
 
@@ -17,13 +16,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Set Docker tag
         id: tag
         run: |
           TAG=$(echo "${{github.ref}}" | sed -e 's,.*/\(.*\),\1,')
           [[ "${{github.ref}}" == "refs/tags/"* ]] && TAG=$(echo $TAG | sed -e 's/^v//')
           [ "$TAG" == "master" ] && TAG=latest
-          # TEMPORARY
           TAG=latest
           echo "::set-output name=tag::$TAG"
 
@@ -35,13 +34,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Build Docker image
         run: make build
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: mirego-builds
-          password: ${{ secrets.MIREGO_GITHUB_PACKAGES_ACCESS_TOKEN }}
+          password: ${{secrets.MIREGO_GITHUB_PACKAGES_ACCESS_TOKEN}}
+
       - name: Push Docker image
         run: make push

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,29 +4,53 @@ on:
   push:
     branches:
       - 'master'
+      - 'feature/add-better-structure-to-cd-workflow' # TEMPORARY
     tags:
       - 'v*'
 
 jobs:
-  push:
+  set-docker-tag:
     runs-on: ubuntu-latest
+
+    outputs:
+      docker-tag: ${{steps.tag.outputs.tag}}
 
     steps:
       - uses: actions/checkout@v2
+      - name: Set Docker tag
+        id: tag
+        run: |
+          TAG=$(echo "${{github.ref}}" | sed -e 's,.*/\(.*\),\1,')
+          [[ "${{github.ref}}" == "refs/tags/"* ]] && TAG=$(echo $TAG | sed -e 's/^v//')
+          [ "$TAG" == "master" ] && TAG=latest
+          # TEMPORARY
+          TAG=latest
+          echo "::set-output name=tag::$TAG"
 
+  build:
+    needs: docker-tag
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_TAG: ${{needs.set-docker-tag.outputs.tag}}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Docker image
+        run: make build
+
+  push:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_TAG: ${{needs.set-docker-tag.outputs.tag}}
+
+    steps:
+      - uses: actions/checkout@v2
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: mirego-builds
           password: ${{ secrets.MIREGO_GITHUB_PACKAGES_ACCESS_TOKEN }}
-
-      - name: Build and push image
-        run: |
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          # Use Docker `latest` tag convention for master
-          [ "$VERSION" == "master" ] && VERSION=latest
-          VERSION=$VERSION make build
-          VERSION=$VERSION make push
+      - name: Push Docker image
+        run: make push

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -9,7 +9,7 @@ on:
       - 'v*'
 
 jobs:
-  set-docker-tag:
+  docker-tag:
     runs-on: ubuntu-latest
 
     outputs:
@@ -27,25 +27,16 @@ jobs:
           TAG=latest
           echo "::set-output name=tag::$TAG"
 
-  build:
-    needs: set-docker-tag
+  build_and_push:
+    needs: docker-tag
     runs-on: ubuntu-latest
     env:
-      DOCKER_TAG: ${{needs.set-docker-tag.outputs.docker-tag}}
+      DOCKER_TAG: ${{needs.docker-tag.outputs.docker-tag}}
 
     steps:
       - uses: actions/checkout@v2
       - name: Build Docker image
         run: make build
-
-  push:
-    needs: build
-    runs-on: ubuntu-latest
-    env:
-      DOCKER_TAG: ${{needs.set-docker-tag.outputs.tag}}
-
-    steps:
-      - uses: actions/checkout@v2
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # Build configuration
 # -------------------
 
-VERSION ?= `git rev-parse HEAD`
+DOCKER_TAG ?= `git rev-parse HEAD`
 DOCKER_REGISTRY = ghcr.io
-DOCKER_LOCAL_IMAGE = mirego/killswitch:$(VERSION)
+DOCKER_LOCAL_IMAGE = mirego/killswitch:$(DOCKER_TAG)
 DOCKER_REMOTE_IMAGE = $(DOCKER_REGISTRY)/$(DOCKER_LOCAL_IMAGE)
 
 # Linter and formatter configuration
@@ -23,8 +23,8 @@ help: header targets
 header:
 	@echo "\033[34mEnvironment\033[0m"
 	@echo "\033[34m---------------------------------------------------------------\033[0m"
-	@printf "\033[33m%-23s\033[0m" "VERSION"
-	@printf "\033[35m%s\033[0m" $(VERSION)
+	@printf "\033[33m%-23s\033[0m" "DOCKER_TAG"
+	@printf "\033[35m%s\033[0m" $(DOCKER_TAG)
 	@echo ""
 	@printf "\033[33m%-23s\033[0m" "DOCKER_REGISTRY"
 	@printf "\033[35m%s\033[0m" $(DOCKER_REGISTRY)


### PR DESCRIPTION
## 📖 Description and motivation

Instead of having a **single step** that does:

1. Figuring out what the Docker image tag should be
2. Building the Docker image
3. Pushing the Docker image to the registry

We now have three steps, split into two jobs:

1. A job to figure out what the Docker image tag should be
2. Another job with two separate steps to build then push the Docker image

## 👷 Work done

#### Tasks

- [x] Split a single step into three separate steps across two jobs

## 🎉 Result

The result is a nicer YAML file ☺️

## 🦀 Dispatch

`#dispatch/devops`
