### PR TITLE
Add explicit version number for all ActiveRecord migrations

### DIFF
--- a/db/migrate/20131108183954_create_applications.rb
+++ b/db/migrate/20131108183954_create_applications.rb
@@ -1,4 +1,4 @@
-class CreateApplications < ActiveRecord::Migration
+class CreateApplications < ActiveRecord::Migration[4.2]
   def change
     create_table :applications do |t|
       t.string :name

--- a/db/migrate/20131108184040_create_projects.rb
+++ b/db/migrate/20131108184040_create_projects.rb
@@ -1,4 +1,4 @@
-class CreateProjects < ActiveRecord::Migration
+class CreateProjects < ActiveRecord::Migration[4.2]
   def change
     create_table :projects do |t|
       t.string :name

--- a/db/migrate/20131108184334_add_project_key.rb
+++ b/db/migrate/20131108184334_add_project_key.rb
@@ -1,4 +1,4 @@
-class AddProjectKey < ActiveRecord::Migration
+class AddProjectKey < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :key, :string
     add_index :projects, :key

--- a/db/migrate/20131108191020_rename_project_app_id.rb
+++ b/db/migrate/20131108191020_rename_project_app_id.rb
@@ -1,4 +1,4 @@
-class RenameProjectAppId < ActiveRecord::Migration
+class RenameProjectAppId < ActiveRecord::Migration[4.2]
   def change
     rename_column :projects, :app_id, :application_id
   end

--- a/db/migrate/20131112125557_create_friendly_id_slugs.rb
+++ b/db/migrate/20131112125557_create_friendly_id_slugs.rb
@@ -1,4 +1,4 @@
-class CreateFriendlyIdSlugs < ActiveRecord::Migration
+class CreateFriendlyIdSlugs < ActiveRecord::Migration[4.2]
   def change
     create_table :friendly_id_slugs do |t|
       t.string   :slug,           :null => false

--- a/db/migrate/20131112125627_add_slugs_to_applications_and_projects.rb
+++ b/db/migrate/20131112125627_add_slugs_to_applications_and_projects.rb
@@ -1,4 +1,4 @@
-class AddSlugsToApplicationsAndProjects < ActiveRecord::Migration
+class AddSlugsToApplicationsAndProjects < ActiveRecord::Migration[4.2]
   def change
     add_column :applications, :slug, :string
     add_column :projects, :slug, :string

--- a/db/migrate/20131112140005_create_behaviors.rb
+++ b/db/migrate/20131112140005_create_behaviors.rb
@@ -1,4 +1,4 @@
-class CreateBehaviors < ActiveRecord::Migration
+class CreateBehaviors < ActiveRecord::Migration[4.2]
   def change
     create_table :behaviors do |t|
       t.references :project

--- a/db/migrate/20131112194936_add_sort_order_to_behaviors.rb
+++ b/db/migrate/20131112194936_add_sort_order_to_behaviors.rb
@@ -1,4 +1,4 @@
-class AddSortOrderToBehaviors < ActiveRecord::Migration
+class AddSortOrderToBehaviors < ActiveRecord::Migration[4.2]
   def change
     add_column :behaviors, :behavior_order, :integer
   end

--- a/db/migrate/20131119114353_devise_create_users.rb
+++ b/db/migrate/20131119114353_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table(:users) do |t|
       t.string :name

--- a/db/migrate/20131119155530_add_slug_to_users.rb
+++ b/db/migrate/20131119155530_add_slug_to_users.rb
@@ -1,4 +1,4 @@
-class AddSlugToUsers < ActiveRecord::Migration
+class AddSlugToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :slug, :string
   end

--- a/db/migrate/20131120155642_add_deleted_at_to_models.rb
+++ b/db/migrate/20131120155642_add_deleted_at_to_models.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToModels < ActiveRecord::Migration
+class AddDeletedAtToModels < ActiveRecord::Migration[4.2]
   def change
     add_column :applications, :deleted_at, :datetime
     add_index :applications, [:slug, :deleted_at], name: "index_applications_on_slug_and_deleted_at"

--- a/db/migrate/20131224183944_remove_unique_index_on_applications.rb
+++ b/db/migrate/20131224183944_remove_unique_index_on_applications.rb
@@ -1,4 +1,4 @@
-class RemoveUniqueIndexOnApplications < ActiveRecord::Migration
+class RemoveUniqueIndexOnApplications < ActiveRecord::Migration[4.2]
   def up
     remove_index :applications, :slug
   end

--- a/db/migrate/20131224184148_remove_a_lot_of_indexes.rb
+++ b/db/migrate/20131224184148_remove_a_lot_of_indexes.rb
@@ -1,4 +1,4 @@
-class RemoveALotOfIndexes < ActiveRecord::Migration
+class RemoveALotOfIndexes < ActiveRecord::Migration[4.2]
   def up
     remove_index "applications", ["slug", "deleted_at"]
     remove_index "behaviors", ["id", "deleted_at"]

--- a/db/migrate/20131224184526_create_organizations.rb
+++ b/db/migrate/20131224184526_create_organizations.rb
@@ -1,4 +1,4 @@
-class CreateOrganizations < ActiveRecord::Migration
+class CreateOrganizations < ActiveRecord::Migration[4.2]
   def change
     create_table :organizations do |t|
       t.string :name

--- a/db/migrate/20131230183006_add_camaraderie.rb
+++ b/db/migrate/20131230183006_add_camaraderie.rb
@@ -1,4 +1,4 @@
-class AddCamaraderie < ActiveRecord::Migration
+class AddCamaraderie < ActiveRecord::Migration[4.2]
   def up
     create_table :memberships do |t|
       t.references :user

--- a/db/migrate/20131231152100_add_recoverable_fields_to_users.rb
+++ b/db/migrate/20131231152100_add_recoverable_fields_to_users.rb
@@ -1,4 +1,4 @@
-class AddRecoverableFieldsToUsers < ActiveRecord::Migration
+class AddRecoverableFieldsToUsers < ActiveRecord::Migration[4.2]
   def change
     change_table :users do |t|
       t.string :reset_password_token

--- a/db/migrate/20140219181729_create_versions.rb
+++ b/db/migrate/20140219181729_create_versions.rb
@@ -1,4 +1,4 @@
-class CreateVersions < ActiveRecord::Migration
+class CreateVersions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :versions do |t|
       t.string   :item_type, :null => false

--- a/db/migrate/20140220160947_rename_behavior_version_to_version_number.rb
+++ b/db/migrate/20140220160947_rename_behavior_version_to_version_number.rb
@@ -1,4 +1,4 @@
-class RenameBehaviorVersionToVersionNumber < ActiveRecord::Migration
+class RenameBehaviorVersionToVersionNumber < ActiveRecord::Migration[4.2]
   def change
     rename_column :behaviors, :version, :version_number
   end

--- a/db/migrate/20141223195846_add_is_super_admin_to_organizations.rb
+++ b/db/migrate/20141223195846_add_is_super_admin_to_organizations.rb
@@ -1,4 +1,4 @@
-class AddIsSuperAdminToOrganizations < ActiveRecord::Migration
+class AddIsSuperAdminToOrganizations < ActiveRecord::Migration[4.2]
   def change
     add_column :organizations, :super_admin, :boolean, default: false
   end

--- a/db/migrate/20150610135602_add_organization_cache_counters.rb
+++ b/db/migrate/20150610135602_add_organization_cache_counters.rb
@@ -1,4 +1,4 @@
-class AddOrganizationCacheCounters < ActiveRecord::Migration
+class AddOrganizationCacheCounters < ActiveRecord::Migration[4.2]
   def change
     add_column :organizations, :memberships_count, :integer, default: 0
     add_column :organizations, :applications_count, :integer, default: 0

--- a/db/migrate/20180420163300_add_datetime_to_behaviors.rb
+++ b/db/migrate/20180420163300_add_datetime_to_behaviors.rb
@@ -1,4 +1,4 @@
-class AddDatetimeToBehaviors < ActiveRecord::Migration
+class AddDatetimeToBehaviors < ActiveRecord::Migration[4.2]
   def change
     add_column :behaviors, :time_operator, :string
     add_column :behaviors, :time, :datetime

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 2018_04_20_163300) do
     t.string "version_number"
     t.string "version_operator"
     t.string "language"
-    t.json "data", default: {}
+    t.json "data", default: "{}"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "behavior_order"


### PR DESCRIPTION
## 📖 Description and motivation

When running the initial migrations, an error was occuring:

```
| StandardError: An error has occurred, this and all later migrations canceled:
|
| Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:
|
|   class CreateApplications < ActiveRecord::Migration[4.2]
```

Specifying a version number [is now required](https://guides.rubyonrails.org/active_record_migrations.html) (it was not before).

This should fix #17.

## 👷 Work done

#### Tasks

- [x] Add `[4.2]` version number to all existing migrations

## 🦀 Dispatch

`#dispatch/rails`
