### PR TITLE
Add version number on homepage

### DIFF
--- a/app/assets/stylesheets/components/_homepage.scss
+++ b/app/assets/stylesheets/components/_homepage.scss
@@ -41,3 +41,9 @@
     }
   }
 }
+
+.homepage-version {
+  opacity: 0.5;
+  margin-top: 30px;
+  font-size: 12px;
+}

--- a/app/helpers/html_helper.rb
+++ b/app/helpers/html_helper.rb
@@ -23,4 +23,8 @@ module HtmlHelper
   def bool_icon(value)
     value ? icon(:check) : nil
   end
+
+  def version
+    "v#{Killswitch::Application::VERSION}"
+  end
 end

--- a/app/views/web/home/show.html.erb
+++ b/app/views/web/home/show.html.erb
@@ -11,5 +11,7 @@
     </div>
 
     <%= link_to icon(:user, t('.sign_in')), new_user_session_path, class: 'btn btn-primary' %>
+
+    <div class="homepage-version"><%= version %></div>
   </div>
 </div>


### PR DESCRIPTION
## 📖 Description and motivation

We want to show the version number to help debugging.

## 🎉 Result

<img width="1185" alt="" src="https://user-images.githubusercontent.com/11348/193133113-6caef73f-5c4e-48d6-8c69-ab0423450a53.png">

## 🦀 Dispatch

`#dispatch/rails`