### PR TITLE
Add orphan user message for user without organizations

### DIFF
--- a/app/controllers/web/home_controller.rb
+++ b/app/controllers/web/home_controller.rb
@@ -5,6 +5,8 @@ class Web::HomeController < Web::ApplicationController
     return if current_user.blank?
 
     organization = current_user.organizations.first
+    return if organization.blank?
+
     redirect_to web_organization_applications_path(organization_id: organization)
   end
 end

--- a/app/views/web/home/show.html.erb
+++ b/app/views/web/home/show.html.erb
@@ -1,17 +1,21 @@
-<% content_for(:hide_navigation, true) %>
+<% if current_user %>
+  <%= t('.orphan') %>
+<% else %>
+  <% content_for(:hide_navigation, true) %>
 
-<div class="homepage">
-  <div class="homepage-content">
-    <%= link_to root_path, class: "homepage-logo" do %>
-      <%= icon(:shield) %>
-    <% end %>
+  <div class="homepage">
+    <div class="homepage-content">
+      <%= link_to root_path, class: "homepage-logo" do %>
+        <%= icon(:shield) %>
+      <% end %>
 
-    <div class="homepage-intro">
-      <%= t('.intro') %>
+      <div class="homepage-intro">
+        <%= t('.intro') %>
+      </div>
+
+      <%= link_to icon(:user, t('.sign_in')), new_user_session_path, class: 'btn btn-primary' %>
+
+      <div class="homepage-version"><%= version %></div>
     </div>
-
-    <%= link_to icon(:user, t('.sign_in')), new_user_session_path, class: 'btn btn-primary' %>
-
-    <div class="homepage-version"><%= version %></div>
   </div>
-</div>
+<% end %>

--- a/config/locales/home.en.yml
+++ b/config/locales/home.en.yml
@@ -4,4 +4,5 @@ en:
     home:
       show:
         intro: Killswitch is a clever control panel that allows mobile developers to apply runtime version-specific behaviors to their iOS or Android application.
+        orphan: You are signed in but you do not belong to any organization. Please contact your system administrator.
         sign_in: Sign in


### PR DESCRIPTION
## 📖 Description and motivation

If, for some reason, a user is able to log in but has no organization memberships, we would show them an internal error message.

Now we show a custom message for this situation.

## 👷 Work done

#### Tasks

- [x] Prevent internal error on orphan user login
- [x] Show custom message

## 🎉 Result

<img width="938" alt="" src="https://user-images.githubusercontent.com/11348/196529820-9fb537f9-5e1c-4989-a37a-f48d7772d7b1.png">

## 🦀 Dispatch

`#dispatch/rails`
