### PR TITLE
Rename default branch to `main`

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,7 +3,7 @@ name: CD
 on:
   push:
     branches:
-      - 'master'
+      - main
     tags:
       - 'v*'
 
@@ -22,7 +22,7 @@ jobs:
         run: |
           TAG=$(echo "${{github.ref}}" | sed -e 's,.*/\(.*\),\1,')
           [[ "${{github.ref}}" == "refs/tags/"* ]] && TAG=$(echo $TAG | sed -e 's/^v//')
-          [ "$TAG" == "master" ] && TAG=latest
+          [ "$TAG" == "main" ] && TAG=latest
           echo "::set-output name=tag::$TAG"
 
   build-and-push:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,9 +3,9 @@ name: "CodeQL"
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
-    branches: 
+    branches:
       - '**'
   schedule:
     - cron: '0 13 * * 1'

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The project exposes a `GET /health` route that contains checks to make sure the 
 
 A Docker image can be created with `make build` and pushed to a registry with `make push`.
 
-[Official Docker images](https://github.com/mirego/killswitch/pkgs/container/killswitch) can be pulled from GitHub Container registry. For example, to get the latest `master` image:
+[Official Docker images](https://github.com/mirego/killswitch/pkgs/container/killswitch) can be pulled from GitHub Container registry. For example, to get the latest `main` image:
 
 ```shell-session
 $ docker pull ghcr.io/mirego/killswitch:latest
@@ -218,7 +218,7 @@ $ docker pull ghcr.io/mirego/killswitch:latest
 
 ## License
 
-Killswitch is © 2013-2022 [Mirego](https://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause). See the [`LICENSE.md`](https://github.com/mirego/killswitch/blob/master/LICENSE.md) file.
+Killswitch is © 2013-2022 [Mirego](https://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause). See the [`LICENSE.md`](https://github.com/mirego/killswitch/blob/main/LICENSE.md) file.
 
 The shield logo is based on [this lovely icon by Kimmi Studio](https://thenounproject.com/icon/shield-1055246/), from The Noun Project. Used under a [Creative Commons BY 3.0](http://creativecommons.org/licenses/by/3.0/) license.
 


### PR DESCRIPTION
## 📖 Description and motivation

The repo now uses `main` as its default branch. This PR updates old references.

## 🦀 Dispatch

_No, thanks!_
