### PR TITLE
Upgrade ActiveRecord::JSONValidator and improve error messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 ruby '2.7.5'
 
-gem 'activerecord_json_validator', '1.3.0'
+gem 'activerecord_json_validator', '~> 2.1.0'
 gem 'autoprefixer-rails', '6.4.0.1'
 gem 'bootsnap'
 gem 'bourgeois'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,9 +55,9 @@ GEM
     activerecord (6.1.6.1)
       activemodel (= 6.1.6.1)
       activesupport (= 6.1.6.1)
-    activerecord_json_validator (1.3.0)
-      activerecord (>= 4.2.0, < 7)
-      json-schema (~> 2.8)
+    activerecord_json_validator (2.1.2)
+      activerecord (>= 4.2.0, < 8)
+      json_schemer (~> 0.2.18)
     activestorage (6.1.6.1)
       actionpack (= 6.1.6.1)
       activejob (= 6.1.6.1)
@@ -112,6 +112,8 @@ GEM
     dotenv (0.9.0)
     dotenv-rails (0.9.0)
       dotenv (= 0.9.0)
+    ecma-re-validator (0.4.0)
+      regexp_parser (~> 2.2)
     erubi (1.11.0)
     execjs (2.8.1)
     factory_girl (4.2.0)
@@ -141,6 +143,7 @@ GEM
       rails (>= 4.0.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hana (1.3.7)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
@@ -148,8 +151,11 @@ GEM
       railties (>= 3.1.0)
       turbolinks
     json (2.6.1)
-    json-schema (2.8.1)
-      addressable (>= 2.4)
+    json_schemer (0.2.23)
+      ecma-re-validator (~> 0.3)
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      uri_template (~> 0.7)
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -227,6 +233,7 @@ GEM
     rake (13.0.6)
     ranked-model (0.3)
       activerecord (>= 3.1.12)
+    regexp_parser (2.6.1)
     request_store (1.5.0)
       rack (>= 1.4)
     responders (3.0.1)
@@ -303,6 +310,7 @@ GEM
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     unicode-display_width (1.6.1)
+    uri_template (0.7.0)
     versionomy (0.5.0)
       blockenspiel (~> 0.5)
     warden (1.2.9)
@@ -316,7 +324,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord_json_validator (= 1.3.0)
+  activerecord_json_validator (~> 2.1.0)
   autoprefixer-rails (= 6.4.0.1)
   bootsnap
   bourgeois

--- a/app/models/behavior.rb
+++ b/app/models/behavior.rb
@@ -3,7 +3,7 @@ class Behavior < ApplicationRecord
   VERSION_OPERATORS = { 'lt' => :<, 'lte' => :<=, 'eq' => :==, 'gte' => :>=, 'gt' => :> }.freeze
   TIME_OPERATORS = { 'lt' => :<, 'gt' => :> }.freeze
   LANGUAGES = %w(fr en de es it pt).freeze
-  DATA_JSON_SCHEMA = Rails.root.join('config/schemas/behavior_data.jsonschema').to_s
+  DATA_JSON_SCHEMA = Rails.root.join('config', 'schemas', 'behavior_data.jsonschema')
 
   # Validations
   validates :project, presence: true
@@ -12,7 +12,7 @@ class Behavior < ApplicationRecord
   validates :time, presence: true, if: :time_operator?
   validates :time_operator, presence: true, inclusion: { in: TIME_OPERATORS.keys }, if: :time?
   validates :language, inclusion: { in: LANGUAGES }, allow_nil: true
-  validates :data, presence: true, json: { schema: DATA_JSON_SCHEMA, message: ->(errors) { format_invalid_json_errors(errors) } }
+  validates :data, presence: true, json: { schema: DATA_JSON_SCHEMA, message: ->(error) { error } }
 
   # Associations
   belongs_to :project
@@ -27,11 +27,6 @@ class Behavior < ApplicationRecord
 
   # Scopes
   scope(:ascendingly, -> { rank(:behavior_order) })
-
-  def self.format_invalid_json_errors(errors)
-    errors = errors.map { |error| error }.join(', ')
-    I18n.t('activerecord.errors.messages.invalid_json', errors: errors)
-  end
 
   # Make sure we set `language` to nil if we receive a blank value
   def language=(language)

--- a/app/models/behavior.rb
+++ b/app/models/behavior.rb
@@ -3,7 +3,7 @@ class Behavior < ApplicationRecord
   VERSION_OPERATORS = { 'lt' => :<, 'lte' => :<=, 'eq' => :==, 'gte' => :>=, 'gt' => :> }.freeze
   TIME_OPERATORS = { 'lt' => :<, 'gt' => :> }.freeze
   LANGUAGES = %w(fr en de es it pt).freeze
-  DATA_JSON_SCHEMA = Rails.root.join('config', 'schemas', 'behavior_data.jsonschema')
+  DATA_JSON_SCHEMA = Rails.root.join('config/schemas/behavior_data.jsonschema')
 
   # Validations
   validates :project, presence: true

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -30,6 +30,5 @@ en:
         applications_count: Applications
     errors:
       messages:
-        invalid_json: is not valid JSON (%{errors})
         invalid_email: is not valid email address
         invalid_version: is not valid version number

--- a/config/schemas/behavior_data.jsonschema
+++ b/config/schemas/behavior_data.jsonschema
@@ -1,54 +1,41 @@
 {
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "$schema": "http://json-schema.org/draft-03/schema",
-  "id": "#",
-  "required": false,
-  "additionalProperties": false,
   "properties": {
     "action": {
       "type": "string",
-      "id": "action",
-      "required": true,
       "pattern": "^(ok|kill|alert)$"
     },
     "message": {
-      "type": "string",
-      "id": "message",
-      "required": false
+      "type": "string"
     },
     "buttons": {
       "type": "array",
-      "id": "buttons",
-      "required": false,
       "items": {
         "type": "object",
-        "id": "0",
-        "required": false,
-        "additionalProperties": false,
         "properties": {
-          "label": {
-            "type": "string",
-            "id": "label",
-            "required": true
-          },
           "type": {
-            "type": "label",
-            "id": "type",
-            "required": false,
+            "type": "string",
             "pattern": "^(url|cancel|reload)$"
           },
+          "label": {
+            "type": "string"
+          },
           "url": {
-            "type": "label",
-            "id": "url",
-            "required": false
+            "type": "string"
           },
           "order": {
-            "type": "number",
-            "id": "order",
-            "required": false
+            "type": "integer"
           }
-        }
+        },
+        "required": [
+          "type",
+          "label"
+        ]
       }
     }
-  }
+  },
+  "required": [
+    "action"
+  ]
 }


### PR DESCRIPTION
## 📖 Description and motivation

We were still using an old version of [ActiveRecord::JSONValidator](https://github.com/mirego/activerecord_json_validator). Let’s upgrade to this morning’s fresh release!

## 👷 Work done

#### Tasks

- [x] Upgrade `ActiveRecord::JSONValidator` gem
- [x] Migrate from a `draft-03` schema to `draft-04`
- [x] Change how we handle errors since `json_schemer` outputs nicer messages

#### Additional notes

<!-- What are topics you would like to discuss or require a closer look? -->

## 🎉 Result

<img width="597" alt="" src="https://user-images.githubusercontent.com/11348/203560296-279830ac-83cb-40fc-b235-0585166a8c2b.png">


## 🦀 Dispatch

`#dispatch/rails`
