### PR TITLE
Replace FactoryGirl with FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ group :development, :test do
   gem 'brakeman'
   gem 'bundler-audit'
   gem 'database_cleaner-active_record'
-  gem 'factory_girl_rails'
+  gem "factory_bot_rails"
   gem 'ffaker'
   gem 'parser', '~> 3.2.0'
   gem 'rspec-rails', '~> 6.0'

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ group :development, :test do
   gem 'brakeman'
   gem 'bundler-audit'
   gem 'database_cleaner-active_record'
-  gem "factory_bot_rails"
+  gem 'factory_bot_rails'
   gem 'ffaker'
   gem 'parser', '~> 3.2.0'
   gem 'rspec-rails', '~> 6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,11 +106,11 @@ GEM
       regexp_parser (~> 2.2)
     erubi (1.12.0)
     execjs (2.8.1)
-    factory_girl (4.9.0)
-      activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
-      railties (>= 3.0.0)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -328,7 +328,7 @@ DEPENDENCIES
   cancancan
   database_cleaner-active_record
   devise (~> 4.9)
-  factory_girl_rails
+  factory_bot_rails
   ffaker
   friendly_id
   gaffe (= 1.2.0)

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :application do
     # Attributes
     name { FFaker::Company.name }

--- a/spec/factories/behaviors.rb
+++ b/spec/factories/behaviors.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :behavior do
     # Attributes
     version_number { "#{Random.rand(1..10)}.#{Random.rand(1..9)}.#{Random.rand(1..9)}" }

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :organization do
     # Attributes
     name { FFaker::Company.name }

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :project do
     # Attributes
     name { FFaker::Company.name }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     # Attributes
     name { FFaker::Name.name }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,11 +20,11 @@ RSpec.configure do |config|
   config.order = 'random'
 
   # Inject Factory helper methods
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   # Reload all factories before running the tests (in case they
   # were preloaded with Spring)
-  config.before(:suite) { FactoryGirl.reload }
+  config.before(:suite) { FactoryBot.reload }
 
   config.before(:suite) { DatabaseCleaner.strategy = :truncation }
   config.before(:each) { DatabaseCleaner.start }


### PR DESCRIPTION
## 📖 Description and motivation

Since 2017, FactoryGirl [is now FactoryBot](https://github.com/thoughtbot/factory_bot/blob/main/NAME.md). Let’s use the latest name using [this migration guide](https://github.com/thoughtbot/factory_bot/blob/4-9-0-stable/UPGRADE_FROM_FACTORY_GIRL.md).

## 👷 Work done

#### Tasks

- [x] Replace FactoryGirl with FactoryBot

## 🦀 Dispatch

`#dispatch/rails`
