### PR TITLE
Use concurrent in all GitHub Actions workflows

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -7,6 +7,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   docker-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     concurrency:
-      group: ${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
 
     services:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: '0 13 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   upload-sbom:
     runs-on: ubuntu-20.04

--- a/.github/workflows/vuln-scan.yaml
+++ b/.github/workflows/vuln-scan.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: '30 13 * * 3'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   vuln-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 📖 Description and motivation

We should use [GitHub Actions’ `concurrency`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) to make sure we don’t run useless workflows (workflows that run on outdated code).

## 👷 Work done

#### Tasks

- [x] Add `concurrency` for all workflows

## 🦀 Dispatch

`#dispatch/devops`
