### PR TITLE
Add bundler-audit config to ignore irrelevant rack-cors issue

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,0 +1,3 @@
+---
+ignore:
+  - CVE-2024-27456 # https://github.com/advisories/GHSA-785g-282q-pwvx (packaging issue with rack-cors)


### PR DESCRIPTION
## 📖 Description and motivation

`rack-cors` had a packaging issue with its 2.0.1 version. Since the official way to deploy Killswitch is to use Docker, it shouldn’t impact us.

## 👀 References

- https://github.com/advisories/GHSA-785g-282q-pwvx
- https://github.com/cyu/rack-cors/issues/274