### PR TITLE
Enable Devise’s paranoid mode

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -77,7 +77,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # :http_auth and :token_auth by adding those symbols to the array below.


### PR DESCRIPTION
## 📖 Description and motivation

This pull request enables Devise’s paranoid mode, which prevent the system from revealing too much information (eg. if an email actually exists when requesting a new password).

## 🎉 Result

![](https://github.com/user-attachments/assets/a093e90d-bcb8-4fe5-a67e-21b3e98c29d6)

## 🦀 Dispatch

`#dispatch/rails`
