### PR TITLE
Use official way to configure Sprockets::ES6

### DIFF
--- a/config/initializers/sprockets_es6.rb
+++ b/config/initializers/sprockets_es6.rb
@@ -1,19 +1,6 @@
-module Sprockets
-  class ES6
-    DEFAULT_OPTIONS = {
-      'moduleIds' => true,
-      'modules' => 'amd',
-      'keepModuleIdExtensions' => false,
-      'loose' => %w(es6.classes)
-    }.freeze
-
-    def self.instance
-      @instance ||= new(DEFAULT_OPTIONS)
-    end
-  end
+Sprockets::ES6.configure do |config|
+  config.moduleIds = true
+  config.modules = 'amd'
+  config.keepModuleIdExtensions = false
+  config.loose = %w(es6.classes)
 end
-
-# NOTE: We shouldn’t have to override `Sprockets::ES6.instance` to pass
-#       custom options to the processor. We should simply be able to do this:
-#
-#       Sprockets.register_transformer 'text/ecmascript-6', 'application/javascript', Sprockets::ES6.new(options)


### PR DESCRIPTION
## 📖 Description and motivation

This pull request removes the hackish way of configuring `Sprockets::ES6` options. Instead of monkey-patching the class, we use its `configure` method.

## 🦀 Dispatch

`#dispatch/rails`
