### PR TITLE
Add robots <meta> tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title><%= page_title(base: t('.base_title')) %></title>
+    <meta name="robots" content="noindex, nofollow">
     <meta name="turbolinks-cache-control" content="no-cache">
     <%= stylesheet_link_tag 'application' %>
     <%= javascript_include_tag 'vendor' %>


### PR DESCRIPTION
## 📖 Description and motivation

This pull request adds a simple `<meta name="robots" content="noindex, nofollow">` tag to all pages so they are not indexed.

## 🦀 Dispatch

`#dispatch/rails`
