### PR TITLE
Change `assume_ssl` config to use the opposite of the `force_ssl` setting

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,7 @@ module Killswitch
 
     # Force SSL on everything except '/killswitch' endpoint
     config.middleware.use Rack::SSL, exclude: lambda { |env| Rack::Request.new(env).path == '/killswitch' } if Rails.application.config_for(:settings)[:force_ssl]
+    config.assume_ssl = !Rails.application.config_for(:settings)[:force_ssl]
 
     # Rack::Cors
     config.middleware.insert_before 0, Rack::Cors do

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,9 +36,6 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  config.assume_ssl = true
-
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 


### PR DESCRIPTION
## 📖 Description and motivation

The Rails 8.0 update (#299) brought the `assume_ssl` setting but it shouldn’t always be `true` in production. It should use the `FORCE_SSL` environment variable.

## 🦀 Dispatch

`#dispatch/rails`
