### PR TITLE
Decrease reset password tokens duration to 6 hours

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -191,7 +191,7 @@ Devise.setup do |config|
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to
   # change their passwords.
-  config.reset_password_within = 2.weeks
+  config.reset_password_within = 6.hours
 
   # ==> Configuration for :encryptable
   # Allow you to use another encryption algorithm besides bcrypt (default). You can use


### PR DESCRIPTION
## 📖 Description and motivation

This pull request changes the validity duration of “password reset” tokens (from 2 weeks to 6 hours)

## 🦀 Dispatch

`#dispatch/rails`
