### PR TITLE
Add missing “authorize” calls in Organizations#new and #create

### DIFF
--- a/app/controllers/web/organizations_controller.rb
+++ b/app/controllers/web/organizations_controller.rb
@@ -8,6 +8,7 @@ class Web::OrganizationsController < Web::ApplicationController
   # GET /organizations/new
   def new
     @organization = Organization.new
+    authorize! :create, @organization
   end
 
   # GET /organizations/:id/edit
@@ -16,6 +17,7 @@ class Web::OrganizationsController < Web::ApplicationController
   # POST /organizations
   def create
     @organization = Organization.new(organization_params)
+    authorize! :create, @organization
 
     if @organization.save
       redirect_to web_organizations_path, notice: t('.notice')


### PR DESCRIPTION
## 📖 Description and motivation

This pull request adds missing authorization checks that allowed all users to create organizations (but were not able to access them afterwards).

## 🦀 Dispatch

`#dispatch/rails`
